### PR TITLE
Empty Vertex Array upport

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -941,8 +941,8 @@ class App {
         @method
         @return {VertexArray} New VertexArray object.
     */
-    createVertexArray() {
-        return new VertexArray(this.gl, this.state);
+    createVertexArray(numElements = 0, numInstances = 0) {
+        return new VertexArray(this.gl, this.state, numElements, numInstances);
     }
 
     /**

--- a/src/vertex-array.js
+++ b/src/vertex-array.js
@@ -37,15 +37,15 @@ const CONSTANTS = require("./constants");
 */
 class VertexArray {
     
-    constructor(gl, appState) {
+    constructor(gl, appState, numElements = 0, numInstances = 0) {
         this.gl = gl;
         this.appState = appState;
         this.vertexArray = null;
-        this.numElements = 0;
+        this.numElements = numElements;
         this.indexType = null;
         this.instancedBuffers = 0;
         this.indexed = false;
-        this.numInstances = 0;
+        this.numInstances = numInstances;
 
         this.restore();
     }

--- a/src/vertex-array.js
+++ b/src/vertex-array.js
@@ -47,7 +47,6 @@ class VertexArray {
         this.indexed = false;
         this.numInstances = numInstances;
 
-        this.restore();
     }
 
     /**
@@ -61,10 +60,26 @@ class VertexArray {
             this.appState.vertexArray = null;
         }
 
-        this.vertexArray = this.gl.createVertexArray();
+        if (this.isAllocated()) {
+            this.vertexArray = this.gl.createVertexArray();
+        }
 
         return this;
     }
+
+
+    /**
+        Query if the vertex array has been allocated.
+        Allocation is only necessary if there are buffers attached.
+
+        @method
+        @return {boolean} Allocation state
+     */
+    isAllocated() {
+        return this.vertexArray !== null;
+    }
+
+
 
     /**
         Bind an per-vertex attribute buffer to this vertex array.
@@ -223,6 +238,7 @@ class VertexArray {
         @return {VertexArray} The VertexArray object.
     */
     attributeBuffer(attributeIndex, vertexBuffer, instanced, integer, normalized) {
+        this.ensureAllocated();
         this.gl.bindVertexArray(this.vertexArray);
         this.gl.bindBuffer(vertexBuffer.binding, vertexBuffer.buffer);
 
@@ -265,6 +281,18 @@ class VertexArray {
         this.gl.bindBuffer(vertexBuffer.binding, null);
 
         return this;
+    }
+
+    /**
+     *
+     * @method
+     * @ignore
+     * @return {void}
+     */
+    ensureAllocated() {
+        if (!this.isAllocated()) {
+            this.vertexArray = this.gl.createVertexArray();
+        }
     }
 
 }


### PR DESCRIPTION
Support use case of empty vertex arrays.
cf. #105

Commit currently lacks docs, examples, build/picogl.js.